### PR TITLE
Make rand a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ asm = []
 
 [dependencies]
 num = "*"
-
-[dev-dependencies]
 rand = "*"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 
 #![feature(core_intrinsics, asm, heap_api, associated_consts)]
 #![feature(zero_one, step_trait, unique)]
-#![feature(rand)]
 
 #![cfg_attr(test, feature(test))]
 


### PR DESCRIPTION
This makes libramp use the `rand` library from crates.io, rather than the unstable one from rustc.  This fixes conflicts and mysterious-looking compile errors in dependent code that uses the external `rand` crate.